### PR TITLE
Fixing docker-compose example

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ reaction:
     - MONGO_URL=mongodb://mongo:27017/reaction
 
 mongo:
-  image: mongo:latest --storageEngine=wiredTiger
+  image: mongo:latest
 ```
 
 And then start the app and database containers with...

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ reaction:
 
 mongo:
   image: mongo:latest
+  command: mongod --storageEngine=wiredTiger
 ```
 
 And then start the app and database containers with...


### PR DESCRIPTION
Removing storageEngine reference since it's not supported
```
ERROR: no such image: mongo:latest+--storageEngine=wiredTiger: invalid reference format
```