### PR TITLE
Fix CircleCI deploy step error

### DIFF
--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -18,7 +18,7 @@ docker tag reactioncommerce/base:latest $IMAGE_NAME:$CIRCLE_TAG
 docker tag reactioncommerce/base:latest $IMAGE_NAME:latest
 
 # login to Docker Hub
-docker login -u $DOCKER_USER --password-stdin $DOCKER_PASS
+docker login -u $DOCKER_USER -p $DOCKER_PASS
 
 # push the builds
 docker push $IMAGE_NAME:$CIRCLE_TAG

--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -18,7 +18,7 @@ docker tag reactioncommerce/base:latest $IMAGE_NAME:$CIRCLE_TAG
 docker tag reactioncommerce/base:latest $IMAGE_NAME:latest
 
 # login to Docker Hub
-docker login -u $DOCKER_USER -p $DOCKER_PASS
+docker login -u "$DOCKER_USER" -p "$DOCKER_PASS"
 
 # push the builds
 docker push $IMAGE_NAME:$CIRCLE_TAG


### PR DESCRIPTION
The CI deploy step was failing with a `password` error.

This change fixes that by changing the `--password-stdin` option to `-p`. 

CircleCI gives a warning for this, but we're fine because we’re providing the value via ENV.