### PR TITLE
Substitute disallowed tags in branch name before Docker tagging step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
           name: Discover Docker Tags
           command: |
             mkdir -p docker-cache
-            .circleci/bin/docker-tags "$CIRCLE_SHA1" "$CIRCLE_BRANCH" \
+            .circleci/bin/docker-tags "$CIRCLE_SHA1" "$CIRCLE_BRANCH" | sed 's/\//-/g' \
               > docker-cache/docker-tags.txt
             cat docker-cache/docker-tags.txt
       - run:


### PR DESCRIPTION
Resolves #23 

## Task:
- Discover disallowed character sets in Docker tags
- Implement a character swapping for the disallowed sets before calling the `docker-tag` command.

## Notes

from [Docker Docs](https://docs.docker.com/engine/reference/commandline/tag/#extended-description)
> A tag name must be valid ASCII and may contain lowercase and uppercase letters, digits, underscores, periods and dashes. A tag name may not start with a period or a dash and may contain a maximum of 128 characters.

-- 
Two relevant pieces:
1. "A tag name may not start with a period or a dash"
This restriction also [applies](https://mirrors.edge.kernel.org/pub/software/scm/git/docs/git-check-ref-format.html) to Git branches, so that checks out. 

2. The tag name can not contain `/` (from testing)
This is allowed in a Git branch name, and is what we check for in this PR.