### PR TITLE
Update to Meteor to v1.7.0.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,7 @@ jobs:
   dockerfile-lint:
     <<: *defaults
     docker:
-      - image: hadolint/hadolint
+      - image: hadolint/hadolint:v1.6.6-6-g254b4ff
     steps:
       - checkout
       - setup_remote_docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,6 +138,7 @@ workflows:
           context: reaction-publish-docker
           requires:
             - docker-build
+            - test
       - test:
           context: reaction-validation
           requires:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM node:8.11.2
 
-ARG METEOR_VERSION=1.7.0.1
 ARG NAME=base
 ARG DESCRIPTION="Base Docker image for Reaction."
 ARG URL=https://github.com/reactioncommerce/base
@@ -52,7 +51,7 @@ LABEL maintainer="Reaction Commerce <engineering@reactioncommerce.com>" \
       com.reactioncommerce.docker.git.sha1=$GIT_SHA1 \
       com.reactioncommerce.docker.license=$LICENSE
 
-ENV METEOR_VERSION $METEOR_VERSION
+ENV METEOR_VERSION 1.7.0.1
 ENV REACTION_DOCKER_BUILD true
 ENV APP_SOURCE_DIR /opt/reaction/src
 ENV APP_BUNDLE_DIR /opt/reaction/dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:8.9.4
 
-ARG METEOR_VERSION=1.6.1
+ARG METEOR_VERSION=1.7.0.1
 ARG NAME=base
 ARG DESCRIPTION="Base Docker image for Reaction."
 ARG URL=https://github.com/reactioncommerce/base

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.9.4
+FROM node:8.11.2
 
 ARG METEOR_VERSION=1.7.0.1
 ARG NAME=base

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,4 @@
-## v4.1.0
+## v1.7.0.1-meteor
 
 - Update Meteor version from v1.6.1 to v1.7.0.1
 - Update node version from 8.9.4 to 8.11.2

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+## v4.1.0
+
+- Update Meteor version from v1.6.1 to v1.7.0.1
+
 ## v4.0.2
 
 - Added test script to presence of Meteor and other dependencies in base image

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,7 @@
 ## v4.1.0
 
 - Update Meteor version from v1.6.1 to v1.7.0.1
+- Update node version from 8.9.4 to 8.11.2
 
 ## v4.0.2
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@
 
 - Update Meteor version from v1.6.1 to v1.7.0.1
 - Update node version from 8.9.4 to 8.11.2
+- Change release versioning: henceforth, releases in this repo will be tied to the corresponding Meteor release.
 
 ## v4.0.2
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,19 @@
 
 [![Circle CI](https://circleci.com/gh/reactioncommerce/base/tree/master.svg?style=svg)](https://circleci.com/gh/reactioncommerce/base/tree/master)
 
+With the release of Meteor 1.7, we changed the versioning of this repo and it's Docker builds to align with Meteor's release. Henceforth, releases in this repo will be tied to the corresponding Meteor release.
+
+Current version builds:
+
+| reactioncommerce/base version       | Meteor version  |
+| :----------------------------------:|:---------------:|
+| v1.7.0.1-meteor                     | v1.7.0.1        |
+| v1.7-meteor                         | v1.7            |
+| v1.6.1-meteor                       | v1.6.1          |
+| v4.0.2                              | v1.6.1          |
+
+See [Docker Hub](https://hub.docker.com/r/reactioncommerce/base/tags/) for full list.
+
 ### Build
 
 Add the following to a `Dockerfile` in the root of your Reaction Commerce project:

--- a/README.md
+++ b/README.md
@@ -39,18 +39,6 @@ Run this command to start the app:
 docker-compose -f docker-compose-demo.yml up
 ```
 
-### Build Options
-
-This base image supports setting custom build options that let you modify what gets installed. You can use [Docker build args](https://docs.docker.com/engine/reference/builder/#arg) to accomplish this.
-
-To change the version of Meteor that gets installed, you can specify a version as below:
-
-```sh
-docker build \
-  --build-arg METEOR_VERSION=1.4.2 \
-  -t myorg/myapp:latest .
-```
-
 ## License
 
 [MIT License](./LICENSE.md)

--- a/README.md
+++ b/README.md
@@ -23,11 +23,18 @@ Add the following to a `Dockerfile` in the root of your Reaction Commerce projec
 FROM reactioncommerce/base:v1.7.0.1-meteor
 ```
 
-Then you can build the image with:
+Then you can build the image with this command (after setting your version):
 
 ```sh
-docker build -t reactioncommerce/reaction:latest .
+VERSION=
+docker build \
+  --build-arg TOOL_NODE_FLAGS="--max-old-space-size=4096" \
+  -t reactioncommerce/reaction:${VERSION} .
 ```
+
+Note: Depending on the type of OS running the build, `--max-old-space-size` may require a different value (e.g 2048). See explanation of the Meteor issue [here](https://github.com/meteor/meteor/issues/8513).
+
+See Reaction's sample Dockerfile using the base image [here](https://github.com/reactioncommerce/reaction/blob/master/Dockerfile).
 
 ### Run
 

--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ Current version builds:
 
 See [Docker Hub](https://hub.docker.com/r/reactioncommerce/base/tags/) for full list.
 
-### Build
+### Usage
 
 Add the following to a `Dockerfile` in the root of your Reaction Commerce project:
 
 ```Dockerfile
-FROM reactioncommerce/base:latest
+FROM reactioncommerce/base:v1.7.0.1-meteor
 ```
 
 Then you can build the image with:


### PR DESCRIPTION
## Changes
- Update Meteor version from v1.6.1 to v1.7.0.1
- Update node version from 8.9.4 to 8.11.2

## Note
Change of release version: henceforth, releases in this repo will be tied to the corresponding Meteor release.

Base versions and corresponding meteor versions:

| reactioncommerce/base version       | Meteor version  |
| :----------------------------------:|:---------------:|
| v1.7.0.1-meteor                     | v1.7.0.1        |
| v1.7-meteor                         | v1.7            |
| v1.6.1-meteor                       | v1.6.1          |
| v4.0.2                              | v1.6.1          |