### PR TITLE
Create image for dev to be used directly in Reaction docker-compose.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ defaults: &defaults
 jobs:
   docker-build:
     <<: *defaults
-    parallelism: 3
+    parallelism: 4
     steps:
       - checkout
       - setup_remote_docker

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,10 @@
+## v1.8-meteor-dev
+
+- This is a minor update on the v1.8 version. It contains small changes to the Dockerfile that eliminates a quite redundant build stage in the Reaction app's Dockerfile.
+- The changes are:
+  - Updating $PATH to include location of Meteor and node_modules binaries
+  - Add `mkdir` command to help volume mounting while developing
+
 ## v1.8-meteor
 
 - Update Meteor version to 1.8

--- a/versions/meteor-1.8-dev/Dockerfile
+++ b/versions/meteor-1.8-dev/Dockerfile
@@ -1,0 +1,102 @@
+FROM node:8.11.4
+
+ARG METEOR_VERSION
+ARG NAME=base
+ARG DESCRIPTION="Base Docker image for Reaction."
+ARG URL=https://github.com/reactioncommerce/base
+ARG DOC_URL=https://github.com/reactioncommerce/base
+ARG VCS_URL=https://github.com/reactioncommerce/base
+ARG VCS_REF
+ARG VENDOR
+ARG BUILD_DATE
+ARG BUILD_COMPARE_URL
+ARG BUILD_ENV=test
+ARG BUILD_NUMBER
+ARG BUILD_PLATFORM
+ARG BUILD_PLATFORM_PROJECT_USERNAME
+ARG BUILD_PLATFORM_PROJECT_REPONAME
+ARG BUILD_PULL_REQUESTS
+ARG BUILD_TRIGGERED_BY_TAG
+ARG BUILD_URL
+ARG CIRCLE_WORKSPACE_ID
+ARG CIRCLE_WORKFLOW_ID
+ARG CIRCLE_WORKFLOW_JOB_ID
+ARG CIRCLE_WORKFLOW_UPSTREAM_JOB_IDS
+ARG CIRCLE_WORKSPACE_ID
+ARG GIT_REPOSITORY_URL
+ARG GIT_SHA1
+ARG LICENSE
+
+LABEL maintainer="Reaction Commerce <engineering@reactioncommerce.com>" \
+      com.reactioncommerce.build-date=$BUILD_DATE \
+      com.reactioncommerce.name=$NAME \
+      com.reactioncommerce.description=$DESCRIPTION \
+      com.reactioncommerce.url=$URL \
+      com.reactioncommerce.vcs-url=$VCS_URL \
+      com.reactioncommerce.vcs-ref=$VCS_REF \
+      com.reactioncommerce.vendor=$VENDOR \
+      com.reactioncommerce.docker.build.compare-url=$BUILD_COMPARE_URL \
+      com.reactioncommerce.docker.build.number=$BUILD_NUMBER \
+      com.reactioncommerce.docker.build.platform=$BUILD_PLATFORM \
+      com.reactioncommerce.docker.build.platform.project.username=$BUILD_PLATFORM_PROJECT_USERNAME \
+      com.reactioncommerce.docker.build.platform.project.reponame=$BUILD_PLATFORM_PROJECT_REPONAME \
+      com.reactioncommerce.docker.build.pull-requests=$BUILD_PULL_REQUESTS \
+      com.reactioncommerce.docker.build.triggered-by-tag=$BUILD_TRIGGERED_BY_TAG \
+      com.reactioncommerce.docker.build.url=$BUILD_URL \
+      com.reactioncommerce.docker.build.circle.workflow.id=$CIRCLE_WORKFLOW_ID \
+      com.reactioncommerce.docker.build.circle.workflow.job.id=$CIRCLE_WORKFLOW_JOB_ID \
+      com.reactioncommerce.docker.build.circle.workflow.upstream.job.ids=$CIRCLE_WORKFLOW_UPSTREAM_JOB_IDS \
+      com.reactioncommerce.docker.build.circle.workflow.url=https://circleci.com/workflow-run/$CIRCLE_WORKFLOW_ID \
+      com.reactioncommerce.docker.build.circle.workspace.id=$CIRCLE_WORKSPACE_ID \
+      com.reactioncommerce.docker.git.repository.url=$GIT_REPOSITORY_URL \
+      com.reactioncommerce.docker.git.sha1=$GIT_SHA1 \
+      com.reactioncommerce.docker.license=$LICENSE
+
+ENV METEOR_VERSION $METEOR_VERSION
+ENV REACTION_DOCKER_BUILD true
+ENV APP_SOURCE_DIR /opt/reaction/src
+ENV APP_BUNDLE_DIR /opt/reaction/dist
+ENV PATH $PATH:/home/node/.meteor:$APP_SOURCE_DIR/node_modules/.bin
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+  build-essential \
+  bsdtar \
+  bzip2 \
+  ca-certificates \
+  git \
+  python \
+  wget \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p "$APP_SOURCE_DIR" \
+ && mkdir -p "$APP_BUNDLE_DIR" \
+ && chown -R node "$APP_SOURCE_DIR" \
+ && chown -R node "$APP_BUNDLE_DIR"
+
+RUN npm i -g reaction-cli
+
+USER node
+
+################################
+# install-meteor
+# replaces tar command with bsdtar in the install script (bsdtar -xf "$TARBALL_FILE" -C "$INSTALL_TMPDIR")
+# https://github.com/jshimko/meteor-launchpad/issues/39
+################################
+RUN wget -O /tmp/install_meteor.sh https://install.meteor.com \
+ && sed -i.bak "s/RELEASE=.*/RELEASE=\"$METEOR_VERSION\"/g" /tmp/install_meteor.sh \
+ && sed -i.bak "s/tar -xzf.*/bsdtar -xf \"\$TARBALL_FILE\" -C \"\$INSTALL_TMPDIR\"/g" /tmp/install_meteor.sh \
+ && printf "\\n[-] Installing Meteor %s...\\n" "$METEOR_VERSION" \
+ && sh /tmp/install_meteor.sh \
+ && rm /tmp/install_meteor.sh
+
+# Because `reaction`'s docker-compose.yml uses a named volume for node_modules and named volumes are owned
+# by root by default, we have to initially create node_modules here with correct owner.
+# Without this NPM cannot write packages into node_modules later, when running in a container.
+RUN mkdir "$APP_SOURCE_DIR/node_modules" && chown node "$APP_SOURCE_DIR/node_modules"
+
+WORKDIR $APP_SOURCE_DIR
+COPY test-script.sh .
+# Node flags for the Meteor build tool
+ONBUILD ARG TOOL_NODE_FLAGS
+ONBUILD ENV TOOL_NODE_FLAGS $TOOL_NODE_FLAGS

--- a/versions/meteor-1.8-dev/options
+++ b/versions/meteor-1.8-dev/options
@@ -1,0 +1,2 @@
+export TAGS=(v1.8-meteor-dev)
+export METEOR_VERSION=1.8

--- a/versions/meteor-1.8-dev/test-script.sh
+++ b/versions/meteor-1.8-dev/test-script.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+echo "#### Starting check for correct Meteor installation"
+INSTALLED_METEOR_VERSION=$(meteor --version)
+if [ "$INSTALLED_METEOR_VERSION" == "Meteor $METEOR_VERSION" ]; then
+  echo "Success: Meteor version confirmed";
+else
+  echo "Error: Expected Meteor version $METEOR_VERSION. Found $INSTALLED_METEOR_VERSION"
+  exit 1;
+fi
+
+echo "#### Starting check for APP_SOURCE_DIR"
+if [ -d "$APP_SOURCE_DIR" ]; then
+  echo "Success: APP_SOURCE_DIR exists";
+else
+  echo "Error: APP_SOURCE_DIR $APP_SOURCE_DIR not found";
+  exit 1;
+fi
+
+echo "#### Starting check for APP_SOURCE_DIR owner"
+APP_SOURCE_DIR_OWNER=$(ls -ld "$APP_SOURCE_DIR" | awk '{print $3}');
+if [ "$APP_SOURCE_DIR_OWNER" == "node" ]; then
+  echo "Success: APP_SOURCE_DIR is owned by node user";
+else
+  echo "Error: APP_SOURCE_DIR not owned by node user";
+  exit 1;
+fi
+
+echo "#### Starting check for APP_BUNDLE_DIR"
+if [ -d "$APP_BUNDLE_DIR" ]; then
+  echo "Success: APP_BUNDLE_DIR exists";
+else
+  echo "Error: APP_BUNDLE_DIR $APP_BUNDLE_DIR not found";
+  exit 1;
+fi
+
+echo "#### Starting check for APP_BUNDLE_DIR owner"
+APP_BUNDLE_DIR_OWNER=$(ls -ld "$APP_BUNDLE_DIR" | awk '{print $3}');
+if [ "$APP_BUNDLE_DIR_OWNER" == "node" ]; then
+  echo "Success: APP_BUNDLE_DIR owned by node user";
+else
+  echo "Error: APP_BUNDLE_DIR NOT owned by node user";
+  exit 1;
+fi
+
+echo "#### Starting check for REACTION CLI"
+REACTION_CLI_VERSION=$(reaction -v | grep Reaction);
+if [[ "$REACTION_CLI_VERSION" =~ "Reaction CLI:" ]]; then
+  echo "Success: REACTION CLI found";
+else
+  echo "Error: REACTION CLI not installed";
+  exit 1;
+fi


### PR DESCRIPTION
## Dokerfile Changes:
- Updating $PATH to include location of node_modules binaries
```
-ENV PATH $PATH:/home/node/.meteor
+ENV PATH $PATH:/home/node/.meteor:$APP_SOURCE_DIR/node_modules/.bin
```

- Add `mkdir` command to help volume mounting in dev
```
+# Because `reaction`'s docker-compose.yml uses a named volume for node_modules and named volumes are owned
+# by root by default, we have to initially create node_modules here with correct owner.
+# Without this NPM cannot write packages into node_modules later, when running in a container.
+RUN mkdir "$APP_SOURCE_DIR/node_modules" && chown node "$APP_SOURCE_DIR/node_modules"
+
```
These were previously done in Reaction Dockerfile.

### Separate 1.8 image for dev
Since we already released a 1.8 and these changes will not work in previous versions before the one with the accompanying PR for this update reactioncommerce/reaction#4770, I make this a separate image.

### Usage
In the dev docker-compose.yml:
```
reaction:
  image: reactioncommerce/base:v1.8-meteor-dev
```
The next version after 1.8 should follow the changes here. Those do not need to have separate dev image.